### PR TITLE
FE: `GoogleAuthResponse` 인터페이스를 `index.ts`에 통합

### DIFF
--- a/frontend/src/components/signin/SignInWithGoogle.vue
+++ b/frontend/src/components/signin/SignInWithGoogle.vue
@@ -5,7 +5,7 @@
 <script lang="ts">
 import { Vue } from "vue-class-component";
 import { Prop, Watch } from "vue-property-decorator";
-import { GoogleAuthResponse } from "@/plugins/signin/google/interfaces";
+import { GoogleAuthResponse } from "@/plugins/signin/google";
 
 export default class SignInWithGoogle extends Vue {
   @Prop({ type: Boolean, default: false }) loaded!: boolean;

--- a/frontend/src/plugins/signin/google/index.ts
+++ b/frontend/src/plugins/signin/google/index.ts
@@ -33,6 +33,11 @@ function unload() {
   gsiScript.remove();
   window.google = undefined;
 
+  // Cleanup autoloaded resources
+  document.getElementById("googleidentityservice_button_styles")?.remove();
+  document.getElementById("googleidentityservice")?.remove();
+  document.getElementById("g_a11y_announcement")?.remove();
+
   loadState.value = false;
 }
 

--- a/frontend/src/plugins/signin/google/index.ts
+++ b/frontend/src/plugins/signin/google/index.ts
@@ -1,6 +1,12 @@
 import { reactive } from "vue";
 import waitFor from "@/util/script-waiter";
 
+export interface GoogleAuthResponse {
+  clientId: string,
+  credential: string,
+  select_by: string,
+}
+
 const loadState = reactive({ value: false });
 const gsiScript = document.createElement("script");
 

--- a/frontend/src/plugins/signin/google/interfaces.ts
+++ b/frontend/src/plugins/signin/google/interfaces.ts
@@ -1,5 +1,0 @@
-export interface GoogleAuthResponse {
-  clientId: string,
-  credential: string,
-  select_by: "btn" | string,
-}


### PR DESCRIPTION
인터페이스 딱 하나밖에 없으니 파일을 분리하지 말고 `@/plugins/signin/google/index.ts`에서 바로 참조할 수 있도록 변경