### PR TITLE
feat: jwt기반 login 기능 구현 및 testing

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation "io.springfox:springfox-boot-starter:3.0.0"
+    implementation 'com.auth0:java-jwt:4.0.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/anyone/to/soma/auth/JWTProvider.java
+++ b/backend/src/main/java/anyone/to/soma/auth/JWTProvider.java
@@ -1,0 +1,48 @@
+package anyone.to.soma.auth;
+
+import anyone.to.soma.user.User;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JWTProvider {
+
+
+    private final String secretKey = "secret_temp";
+    private final long accessTokenDurationTime = 10 * 60 * 1000;
+
+    private final Algorithm algorithm = Algorithm.HMAC256(secretKey);
+
+    public String createAccessToken(String email) {
+        return createJWT(email, accessTokenDurationTime);
+    }
+
+    private String createJWT(String email, long tokenDurationTime) {
+        Date now = new Date();
+        Date expirationTime = new Date(now.getTime() + tokenDurationTime);
+
+        return JWT.create()
+                .withSubject(email)
+                .withIssuedAt(now)
+                .withExpiresAt(expirationTime)
+                .sign(algorithm);
+    }
+
+    public User googleOAuthJwtToUser(String token) {
+        DecodedJWT jwt = decodeJWT(token);
+        String id = jwt.getClaim("sub").asString();
+        String email = jwt.getClaim("email").asString();
+        String name = jwt.getClaim("name").asString();
+        return new User(id, email, name);
+    }
+
+    public DecodedJWT decodeJWT(String token) {
+        return JWT.decode(token);
+    }
+
+
+}

--- a/backend/src/main/java/anyone/to/soma/user/User.java
+++ b/backend/src/main/java/anyone/to/soma/user/User.java
@@ -1,0 +1,27 @@
+package anyone.to.soma.user;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User {
+
+    @Id
+    private String id;
+
+    private String email;
+
+    private String name;
+
+    public User(String id, String email, String name) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/anyone/to/soma/user/UserController.java
+++ b/backend/src/main/java/anyone/to/soma/user/UserController.java
@@ -3,6 +3,7 @@ package anyone.to.soma.user;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
@@ -13,7 +14,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/login/google")
+    @PostMapping("/login/google")
     public ResponseEntity<String> doGoogleLogin(HttpServletRequest request) {
         String token = request.getHeader("credential");
         if (token.isBlank()) {

--- a/backend/src/main/java/anyone/to/soma/user/UserController.java
+++ b/backend/src/main/java/anyone/to/soma/user/UserController.java
@@ -1,0 +1,24 @@
+package anyone.to.soma.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/login/google")
+    public ResponseEntity<String> doGoogleLogin(HttpServletRequest request) {
+        String token = request.getHeader("credential");
+        if (token.isBlank()) {
+            throw new IllegalArgumentException();
+        }
+        return ResponseEntity.ok(userService.signInUser(token));
+    }
+}

--- a/backend/src/main/java/anyone/to/soma/user/UserController.java
+++ b/backend/src/main/java/anyone/to/soma/user/UserController.java
@@ -1,5 +1,6 @@
 package anyone.to.soma.user;
 
+import anyone.to.soma.user.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +16,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/login/google")
-    public ResponseEntity<String> doGoogleLogin(HttpServletRequest request) {
+    public ResponseEntity<LoginResponse> doGoogleLogin(HttpServletRequest request) {
         String token = request.getHeader("credential");
         if (token.isBlank()) {
             throw new IllegalArgumentException();

--- a/backend/src/main/java/anyone/to/soma/user/UserRepository.java
+++ b/backend/src/main/java/anyone/to/soma/user/UserRepository.java
@@ -1,0 +1,9 @@
+package anyone.to.soma.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, String> {
+
+}

--- a/backend/src/main/java/anyone/to/soma/user/UserService.java
+++ b/backend/src/main/java/anyone/to/soma/user/UserService.java
@@ -1,0 +1,30 @@
+package anyone.to.soma.user;
+
+import anyone.to.soma.auth.JWTProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final JWTProvider jwtProvider;
+
+
+    @Transactional
+    public String signInUser(String token) {
+        User decodedUser = jwtProvider.googleOAuthJwtToUser(token);
+        String id = decodedUser.getId();
+
+        if (!userRepository.existsById(id)) {
+            id = userRepository.save(decodedUser).getId();
+        }
+
+        User user = userRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        return jwtProvider.createAccessToken(user.getEmail());
+    }
+
+
+}

--- a/backend/src/main/java/anyone/to/soma/user/UserService.java
+++ b/backend/src/main/java/anyone/to/soma/user/UserService.java
@@ -1,6 +1,7 @@
 package anyone.to.soma.user;
 
 import anyone.to.soma.auth.JWTProvider;
+import anyone.to.soma.user.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +13,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final JWTProvider jwtProvider;
 
-
     @Transactional
-    public String signInUser(String token) {
+    public LoginResponse signInUser(String token) {
         User decodedUser = jwtProvider.googleOAuthJwtToUser(token);
         String id = decodedUser.getId();
 
@@ -23,7 +23,8 @@ public class UserService {
         }
 
         User user = userRepository.findById(id).orElseThrow(IllegalArgumentException::new);
-        return jwtProvider.createAccessToken(user.getEmail());
+        String accessToken = jwtProvider.createAccessToken(user.getEmail());
+        return new LoginResponse(user.getName(), user.getEmail(), accessToken);
     }
 
 

--- a/backend/src/main/java/anyone/to/soma/user/dto/LoginResponse.java
+++ b/backend/src/main/java/anyone/to/soma/user/dto/LoginResponse.java
@@ -1,0 +1,14 @@
+package anyone.to.soma.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class LoginResponse {
+    private String name;
+    private String email;
+    private String token;
+}

--- a/backend/src/test/java/anyone/to/soma/auth/JWTProviderTest.java
+++ b/backend/src/test/java/anyone/to/soma/auth/JWTProviderTest.java
@@ -1,0 +1,49 @@
+package anyone.to.soma.auth;
+
+import anyone.to.soma.user.User;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JWTProviderTest {
+
+    private static final String JWT = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3MjdiNmI0OTQwMmI5Y2Y5NWJlNGU4ZmQzOGFhN2U3YzExNjQ0YjEiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJuYmYiOjE2NjA2MzUxNDksImF1ZCI6IjY3NDE3OTgwNzQ2MS01Nms2MW9vOWkzaTVlb2cyZmNpbWo2czFuNDhtc2xiYS5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsInN1YiI6IjEwMzk4NDYxNTk5OTY2OTAxOTA2NiIsImVtYWlsIjoic3dtLnRlYW0uZ295dWtrdXJpQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhenAiOiI2NzQxNzk4MDc0NjEtNTZrNjFvbzlpM2k1ZW9nMmZjaW1qNnMxbjQ4bXNsYmEuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJuYW1lIjoiVEVBTSBHT1lVS0tVUkkiLCJwaWN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EvQUl0YnZta2xaNXJhSExlN2N4OUJtZXpJX0xHMkk5SzBSRk44SUU2SDBSRlg9czk2LWMiLCJnaXZlbl9uYW1lIjoiVEVBTSBHT1lVS0tVUkkiLCJpYXQiOjE2NjA2MzU0NDksImV4cCI6MTY2MDYzOTA0OSwianRpIjoiMWM2MmYxM2E1N2IzNmQ3ZjhjNTE3MGM5ZDhkMTdiZmExMWY5NTdiNCJ9.o34KxH_yShUSp8qqC8hfQcNqH3ZFcBjcKuQUldfcgKegunairnNrQks3CVlJ8zzRS5g80RpqUyk6KTWjYUVMLlfuPHfZx0ZSh4rWu2OLc6kFfV6GvtkWTOnqjw326F8I276v_CI1oBgRx0jP9Mj1ye030-IGqZNFErYlUHCMTDeJRIRalhFGvWUEYXerjXHngbQ0qUMLkx3KYM-NyNojUNB3me70YAVDBlUI0nYf2i662_jvQq4iBWwNxzPb7zAbrVOdkaTpEOZKgmiSOEzeHBDNgBSswceQyg3aVj7NWIVgPa-dYll_qhmpnuPsDuyjkKzmxAFkc_KGaJ0roLFZ7w";
+    private static final String EMAIL = "swm.team.goyukkuri@gmail.com";
+
+    private JWTProvider jwtProvider;
+
+
+    @BeforeEach
+    void setup() {
+        jwtProvider = new JWTProvider();
+    }
+
+    @Test
+    void decodeJWTTest() {
+        DecodedJWT decodedJWT = jwtProvider.decodeJWT(JWT);
+        System.out.println(decodedJWT.getClaim("sub"));
+        System.out.println(decodedJWT.getClaim("email"));
+        System.out.println(decodedJWT.getClaim("name"));
+    }
+
+    @Test
+    void createJWTToken() {
+        String accessToken = jwtProvider.createAccessToken(EMAIL);
+        assertThat(jwtProvider.decodeJWT(accessToken).getSubject()).isEqualTo(EMAIL);
+    }
+
+    @Test
+    void googleOAuthJwtToUserTest() {
+        DecodedJWT decodedJWT = jwtProvider.decodeJWT(JWT);
+        String sub = decodedJWT.getClaim("sub").asString();
+        String email = decodedJWT.getClaim("email").asString();
+
+        User user = jwtProvider.googleOAuthJwtToUser(JWT);
+
+        assertThat(user.getId()).isEqualTo(sub);
+        assertThat(user.getEmail()).isEqualTo(email);
+    }
+
+}

--- a/backend/src/test/java/anyone/to/soma/user/UserServiceTest.java
+++ b/backend/src/test/java/anyone/to/soma/user/UserServiceTest.java
@@ -1,6 +1,7 @@
 package anyone.to.soma.user;
 
 import anyone.to.soma.auth.JWTProvider;
+import anyone.to.soma.user.dto.LoginResponse;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,8 +23,8 @@ class UserServiceTest {
 
     @Test
     void signInUser() {
-        String createdJWT = userService.signInUser(JWT);
-        DecodedJWT decodedJWT = jwtProvider.decodeJWT(createdJWT);
-        assertThat(decodedJWT.getSubject()).isEqualTo(EMAIL);
+        LoginResponse response = userService.signInUser(JWT);
+        DecodedJWT decodedJWT = jwtProvider.decodeJWT(response.getToken());
+        assertThat(decodedJWT.getSubject()).isEqualTo(response.getEmail());
     }
 }

--- a/backend/src/test/java/anyone/to/soma/user/UserServiceTest.java
+++ b/backend/src/test/java/anyone/to/soma/user/UserServiceTest.java
@@ -1,0 +1,29 @@
+package anyone.to.soma.user;
+
+import anyone.to.soma.auth.JWTProvider;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UserServiceTest {
+
+    private static final String JWT = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3MjdiNmI0OTQwMmI5Y2Y5NWJlNGU4ZmQzOGFhN2U3YzExNjQ0YjEiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJuYmYiOjE2NjA2MzUxNDksImF1ZCI6IjY3NDE3OTgwNzQ2MS01Nms2MW9vOWkzaTVlb2cyZmNpbWo2czFuNDhtc2xiYS5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsInN1YiI6IjEwMzk4NDYxNTk5OTY2OTAxOTA2NiIsImVtYWlsIjoic3dtLnRlYW0uZ295dWtrdXJpQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhenAiOiI2NzQxNzk4MDc0NjEtNTZrNjFvbzlpM2k1ZW9nMmZjaW1qNnMxbjQ4bXNsYmEuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJuYW1lIjoiVEVBTSBHT1lVS0tVUkkiLCJwaWN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EvQUl0YnZta2xaNXJhSExlN2N4OUJtZXpJX0xHMkk5SzBSRk44SUU2SDBSRlg9czk2LWMiLCJnaXZlbl9uYW1lIjoiVEVBTSBHT1lVS0tVUkkiLCJpYXQiOjE2NjA2MzU0NDksImV4cCI6MTY2MDYzOTA0OSwianRpIjoiMWM2MmYxM2E1N2IzNmQ3ZjhjNTE3MGM5ZDhkMTdiZmExMWY5NTdiNCJ9.o34KxH_yShUSp8qqC8hfQcNqH3ZFcBjcKuQUldfcgKegunairnNrQks3CVlJ8zzRS5g80RpqUyk6KTWjYUVMLlfuPHfZx0ZSh4rWu2OLc6kFfV6GvtkWTOnqjw326F8I276v_CI1oBgRx0jP9Mj1ye030-IGqZNFErYlUHCMTDeJRIRalhFGvWUEYXerjXHngbQ0qUMLkx3KYM-NyNojUNB3me70YAVDBlUI0nYf2i662_jvQq4iBWwNxzPb7zAbrVOdkaTpEOZKgmiSOEzeHBDNgBSswceQyg3aVj7NWIVgPa-dYll_qhmpnuPsDuyjkKzmxAFkc_KGaJ0roLFZ7w";
+    private static final String EMAIL = "swm.team.goyukkuri@gmail.com";
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private JWTProvider jwtProvider;
+
+    @Test
+    void signInUser() {
+        String createdJWT = userService.signInUser(JWT);
+        DecodedJWT decodedJWT = jwtProvider.decodeJWT(createdJWT);
+        assertThat(decodedJWT.getSubject()).isEqualTo(EMAIL);
+    }
+}


### PR DESCRIPTION
### Overview
- `/login/google` url로  `credential` key에 Google OAuth2 서버에서 받은 JWT 값을 넣은 header를 POST 요청하면 사용할 수 있습니다. 
- 요청이 성공적으로 진행된다면 email을 subject로 하는 JWT가 Body에 담아져 response로 반환됩니다. 
- 로그인 방식은 만약 User가 회원가입이 되어있지 않다면, 회원가입을 진행한 후에 jwt를 반환하며, 회원가입이 되어있다면 jwt를 바로 반환합니다.

### Limitation 
- UserService에서 회원가입에 대한 테스트를 진행하기 어렵습니다.  이는 `signInUser`에서 두가지 책임을 지니기 때문에 나타난 것으로 생각합니다.
1. 유저가 없을 시 회원가입을 진행 후 jwt 반환
2.유저가 있을 시 조회 후 jwt 반환 
 이에 대한 역할을 분리해 테스팅을 진행할 수 있는 고민도 필요할듯 합니다.
- header에 credential 값이 비어있다면 internal server error(500)을 발생시킵니다. 이에 대해 400번대로 별도의 예외처리가 필요할 듯합니다. 

Close #1 