### PR TITLE
프로필 페이지 및 로그아웃 기본 구현

### DIFF
--- a/frontend/src/components/app/global/AppNavbar.vue
+++ b/frontend/src/components/app/global/AppNavbar.vue
@@ -57,6 +57,7 @@ export default class AppNavbar extends Vue {
 
   .app-navbar {
     &__left, &__right {
+      position: relative;
       display: flex;
       align-items: center;
       height: 100%;

--- a/frontend/src/components/app/global/AppNavbar.vue
+++ b/frontend/src/components/app/global/AppNavbar.vue
@@ -14,7 +14,8 @@
     </div>
 
     <div class="app-navbar__right">
-      <app-navbar-profile-menu :profileImageUrl="tempProfileImage" />
+      <app-navbar-profile-menu v-if="!$route.meta.hideNavbarMenu"
+                              :profileImageUrl="tempProfileImage" />
     </div>
   </nav>
 </template>

--- a/frontend/src/components/app/global/AppNavbar.vue
+++ b/frontend/src/components/app/global/AppNavbar.vue
@@ -4,7 +4,7 @@
       <v-slide-x-transition group
                             leave-absolute
                             origin="center center">
-        <a v-show="isCurrentRouteNotHome"
+        <a v-if="isCurrentRouteNotHome"
            key="1"
            @click="$router.back()"
            class="app-navbar__go-back"><v-icon>mdi-chevron-left</v-icon></a>

--- a/frontend/src/components/app/global/AppNavbarProfileMenu.vue
+++ b/frontend/src/components/app/global/AppNavbarProfileMenu.vue
@@ -48,7 +48,7 @@ export default class AppNavbarProfileMenu extends Vue {
   flex-direction: row;
   align-items: center;
   height: 100%;
-  background-color: rgba($color-foreground, 0.33);
+  background-color: lighten($color-background, 20%);
   border-radius: 999em;
   box-shadow: 0 0.33em 0.75em rgba(24, 24, 24, 0.5);
 }

--- a/frontend/src/components/app/global/AppNavbarProfileMenu.vue
+++ b/frontend/src/components/app/global/AppNavbarProfileMenu.vue
@@ -48,7 +48,7 @@ export default class AppNavbarProfileMenu extends Vue {
   flex-direction: row;
   align-items: center;
   height: 100%;
-  background-color: lighten($color-background, 20%);
+  background-color: rgba($color-foreground, 0.33);
   border-radius: 999em;
   box-shadow: 0 0.33em 0.75em rgba(24, 24, 24, 0.5);
 }

--- a/frontend/src/components/app/global/AppNavbarProfileMenu.vue
+++ b/frontend/src/components/app/global/AppNavbarProfileMenu.vue
@@ -1,9 +1,26 @@
 <template>
-  <div class="app-navbar__profile-menu animation-button">
-    <profile-image class="app-navbar__profile-menu__profile-image"
+  <div class="app-navbar__profile animation-button"
+       @click="menuOpened = !menuOpened">
+    <profile-image class="app-navbar__profile__profile-image"
                    :srcUrl="profileImageUrl" />
-    <div class="app-navbar__profile-menu__nickname">{{ $store.state.auth.userBasicInfo.nickname }}</div>
+    <div class="app-navbar__profile__nickname">{{ $store.state.auth.userBasicInfo.nickname }}</div>
   </div>
+
+  <v-slide-y-transition>
+    <div v-show="menuOpened"
+        class="app-navbar__profile-menu">
+      <router-link class="animation-button"
+                   :to="{ name: 'profile' }"
+                   @click="onMenuClick">
+        <v-icon>mdi-account</v-icon> <span>내 프로필 보기</span>
+      </router-link>
+      <router-link class="animation-button"
+                   :to="{ name: 'logout' }"
+                   @click="onMenuClick">
+        <v-icon>mdi-logout</v-icon> <span>로그아웃</span>
+      </router-link>
+    </div>
+  </v-slide-y-transition>
 </template>
 
 <script lang="ts">
@@ -18,20 +35,28 @@ import ProfileImage from "./ProfileImage.vue";
 })
 export default class AppNavbarProfileMenu extends Vue {
   @Prop({ type: String, required: true }) profileImageUrl! :string;
+
+  menuOpened = false;
+
+  onMenuClick(): void { this.menuOpened = false; }
 }
 </script>
 
 <style lang="scss" scoped>
-.app-navbar__profile-menu {
-  cursor: pointer;
+@mixin button-style {
   display: flex;
   flex-direction: row;
   align-items: center;
   height: 100%;
-  padding: 0.5em 1.25em 0.5em 0.5em;
   background-color: rgba($color-foreground, 0.2);
   border-radius: 999em;
   box-shadow: 0 0.33em 0.75em rgba(24, 24, 24, 0.5);
+}
+
+.app-navbar__profile {
+  @include button-style();
+  cursor: pointer;
+  padding: 0.5em 1.25em 0.5em 0.5em;
 
   &__profile-image {
     aspect-ratio: 1;
@@ -46,6 +71,24 @@ export default class AppNavbarProfileMenu extends Vue {
   &__nickname {
     font-size: 1.5em;
     font-weight: 500;
+  }
+}
+
+.app-navbar__profile-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  font-size: 1.25em;
+
+  & > a {
+    @include button-style();
+    padding: 0.75em 1.25em;
+    margin: 0.5em 0;
+    justify-content: space-between;
+
+    & > span {
+      margin-left: 1em;
+    }
   }
 }
 </style>

--- a/frontend/src/components/app/global/AppNavbarProfileMenu.vue
+++ b/frontend/src/components/app/global/AppNavbarProfileMenu.vue
@@ -1,26 +1,26 @@
 <template>
-  <div class="app-navbar__profile animation-button"
-       @click="menuOpened = !menuOpened">
-    <profile-image class="app-navbar__profile__profile-image"
-                   :srcUrl="profileImageUrl" />
-    <div class="app-navbar__profile__nickname">{{ $store.state.auth.userBasicInfo.nickname }}</div>
-  </div>
-
-  <v-slide-y-transition>
-    <div v-show="menuOpened"
-        class="app-navbar__profile-menu">
-      <router-link class="animation-button"
-                   :to="{ name: 'profile' }"
-                   @click="onMenuClick">
-        <v-icon>mdi-account</v-icon> <span>내 프로필 보기</span>
-      </router-link>
-      <router-link class="animation-button"
-                   :to="{ name: 'logout' }"
-                   @click="onMenuClick">
-        <v-icon>mdi-logout</v-icon> <span>로그아웃</span>
-      </router-link>
+    <div class="app-navbar__profile animation-button"
+        @click="menuOpened = !menuOpened">
+      <profile-image class="app-navbar__profile__profile-image"
+                    :srcUrl="profileImageUrl" />
+      <div class="app-navbar__profile__nickname">{{ $store.state.auth.userBasicInfo.nickname }}</div>
     </div>
-  </v-slide-y-transition>
+
+    <v-slide-y-transition>
+      <div v-show="menuOpened"
+          class="app-navbar__profile-menu">
+        <router-link class="animation-button"
+                    :to="{ name: 'profile' }"
+                    @click="onMenuClick">
+          <v-icon>mdi-account</v-icon> <span>내 프로필 보기</span>
+        </router-link>
+        <router-link class="animation-button"
+                    :to="{ name: 'logout' }"
+                    @click="onMenuClick">
+          <v-icon>mdi-logout</v-icon> <span>로그아웃</span>
+        </router-link>
+      </div>
+    </v-slide-y-transition>
 </template>
 
 <script lang="ts">

--- a/frontend/src/components/app/global/AppNavbarProfileMenu.vue
+++ b/frontend/src/components/app/global/AppNavbarProfileMenu.vue
@@ -48,7 +48,7 @@ export default class AppNavbarProfileMenu extends Vue {
   flex-direction: row;
   align-items: center;
   height: 100%;
-  background-color: rgba($color-foreground, 0.2);
+  background-color: rgba($color-foreground, 0.33);
   border-radius: 999em;
   box-shadow: 0 0.33em 0.75em rgba(24, 24, 24, 0.5);
 }

--- a/frontend/src/components/app/signin/SignInWithGoogle.vue
+++ b/frontend/src/components/app/signin/SignInWithGoogle.vue
@@ -37,7 +37,7 @@ export default class SignInWithGoogle extends Vue {
     try {
       const response = (await bePOST("/login/google", {}, {
         credential: data.credential,
-      })) as {
+      })).data as {
         name: string,
         email: string,
         token: string,

--- a/frontend/src/pages/app/signin/LogoutPage.vue
+++ b/frontend/src/pages/app/signin/LogoutPage.vue
@@ -1,11 +1,16 @@
 <template>
-  <div></div>
+  <div>😥 로그아웃하고 있어요.</div>
 </template>
 
 <script lang="ts">
 import { Vue } from "vue-class-component";
 
 export default class LogoutPage extends Vue {
-
+  mounted(): void {
+    // Unconditional logout
+    this.$store.commit("auth/registerLoginState", null);
+    this.$cookies.remove("userSession");
+    window.location.replace("/");
+  }
 }
 </script>

--- a/frontend/src/pages/app/signin/LogoutPage.vue
+++ b/frontend/src/pages/app/signin/LogoutPage.vue
@@ -1,12 +1,20 @@
 <template>
-  <div>😥 로그아웃하고 있어요.</div>
+  <div>
+    <v-slide-y-reverse-transition>
+      <span v-show="pageMounted">🫠 로그아웃하고 있어요.</span>
+    </v-slide-y-reverse-transition>
+  </div>
 </template>
 
 <script lang="ts">
 import { Vue } from "vue-class-component";
 
 export default class LogoutPage extends Vue {
+  pageMounted = false;
+
   mounted(): void {
+    this.pageMounted = true;
+
     // Unconditional logout
     this.$store.commit("auth/registerLoginState", null);
     this.$cookies.remove("userSession");
@@ -14,3 +22,16 @@ export default class LogoutPage extends Vue {
   }
 }
 </script>
+
+<style scoped>
+div {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 3em;
+  text-align: center;
+  line-height: 1.25;
+}
+</style>

--- a/frontend/src/pages/app/user/ProfilePage.vue
+++ b/frontend/src/pages/app/user/ProfilePage.vue
@@ -6,7 +6,8 @@
 
         <div class="profile__my-area__image-nickname__info">
           <span class="nickname">{{ $store.state.auth.userBasicInfo.nickname }}</span>
-          <span class="info">(나이대) / (성별)</span> <!-- TODO: 이 정보는 다른 사람에게 보여지지 않는다는 툴팁 표시 -->
+          <span class="info"
+                title="이 정보는 다른 사람들에게 보여지지 않아요!">(나이대) / (성별)</span>
         </div>
       </div>
 
@@ -43,6 +44,10 @@ import ProfileImage from "@/components/app/global/ProfileImage.vue";
 })
 export default class ProfilePage extends Vue {
   private tempProfileImage = "https://picsum.photos/seed/toanyone/300";
+
+  mounted(): void {
+    // TODO: request to backend for user profile data
+  }
 }
 </script>
 
@@ -69,6 +74,7 @@ export default class ProfilePage extends Vue {
         align-items: center;
 
         &__info {
+          cursor: help;
           display: flex;
           flex-direction: column;
           justify-content: center;

--- a/frontend/src/pages/app/user/ProfilePage.vue
+++ b/frontend/src/pages/app/user/ProfilePage.vue
@@ -23,7 +23,8 @@
       </div>
     </div>
 
-    <div>프로필 수정 버튼</div>
+    <!-- ↓ TODO: styling -->
+    <router-link :to="{ name: 'profile-edit' }" style="color: #FFFFAA">(프로필 수정 버튼)</router-link>
 
     <h1>통계</h1>
     <div>(icon) nnnn년 nn월 nn일<br />에 마음을 나누기 시작했어요</div>

--- a/frontend/src/pages/app/user/ProfilePage.vue
+++ b/frontend/src/pages/app/user/ProfilePage.vue
@@ -1,11 +1,122 @@
 <template>
-  <div>PROFILE</div>
+  <div id="profile-page-wrapper">
+    <div class="profile__my-area">
+      <div class="profile__my-area__image-nickname">
+        <profile-image :srcUrl="tempProfileImage" />
+
+        <div class="profile__my-area__image-nickname__info">
+          <span class="nickname">{{ $store.state.auth.userBasicInfo.nickname }}</span>
+          <span class="info">(나이대) / (성별)</span> <!-- TODO: 이 정보는 다른 사람에게 보여지지 않는다는 툴팁 표시 -->
+        </div>
+      </div>
+
+      <div class="profile__my-area__achievements">
+        <div class="profile__my-area__achievements__item">
+          <span class="title">달성한 업적</span>
+          <span class="content">nn개 <small>/ nn개</small></span>
+        </div>
+        <div class="profile__my-area__achievements__item">
+          <span class="title">총 편지 작성 개수</span>
+          <span class="content">nn통</span>
+        </div>
+      </div>
+    </div>
+
+    <div>프로필 수정 버튼</div>
+
+    <h1>통계</h1>
+    <div>(icon) nnnn년 nn월 nn일<br />에 마음을 나누기 시작했어요</div>
+    <div>(icon) 총 nn일<br />To. Anyone을 찾아와주셨어요</div>
+    <div>(icon) nn통<br />의 편지를 보냈어요</div>
+    <div>(icon) nn통<br />의 편지를 받았어요</div>
+  </div>
 </template>
 
 <script lang="ts">
-import { Vue } from "vue-class-component";
+import { Options, Vue } from "vue-class-component";
+import ProfileImage from "@/components/app/global/ProfileImage.vue";
 
+@Options({
+  components: {
+    ProfileImage,
+  },
+})
 export default class ProfilePage extends Vue {
-
+  private tempProfileImage = "https://picsum.photos/seed/toanyone/300";
 }
 </script>
+
+<style lang="scss">
+#profile-page-wrapper {
+  margin: auto;
+  width: 80vw;
+
+  .profile {
+    &__my-area {
+      display: flex;
+      justify-content: space-between;
+      padding: 1rem 2rem 1rem 1rem;
+      margin: 1rem;
+      background: rgba($color-secondary, 0.5);
+      border-radius: 10rem 2rem 2rem 10rem;
+
+      & > div {
+        display: flex;
+      }
+
+      &__image-nickname {
+        display: flex;
+        align-items: center;
+
+        &__info {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: flex-start;
+          margin-left: 1.5rem;
+          line-height: 1.5;
+
+          .nickname {
+            font-size: 2em;
+            font-weight: 700;
+          }
+
+          .info {
+            font-size: 1.25em;
+          }
+        }
+      }
+
+      &__achievements {
+        &__item {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          padding: 0 0.75em;
+          border-left: solid currentColor 1px;
+          border-right: solid currentColor 1px;
+
+          & > * {
+            margin: 0.25em 0;
+          }
+
+          .title {
+            font-size: 1.25em;
+          }
+
+          .content {
+            font-size: 1.5em;
+            font-weight: 700;
+
+            small {
+              font-size: 0.75em;
+              font-weight: 400;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+</style>

--- a/frontend/src/plugins/router/index.ts
+++ b/frontend/src/plugins/router/index.ts
@@ -27,7 +27,10 @@ const routes: Array<RouteRecordRaw> = [
       {
         path: "profile",
         name: "profile",
-        meta: { title: "프로필" },
+        meta: {
+          title: "프로필",
+          hideNavbarMenu: true,
+        },
         component: ProfilePage,
       },
       {

--- a/frontend/src/plugins/router/index.ts
+++ b/frontend/src/plugins/router/index.ts
@@ -36,7 +36,10 @@ const routes: Array<RouteRecordRaw> = [
       {
         path: "profile/edit",
         name: "profile-edit",
-        meta: { title: "프로필 수정" },
+        meta: {
+          title: "프로필 수정",
+          hideNavbarMenu: true,
+        },
         component: ProfileEditPage,
       },
 

--- a/frontend/src/util/backend.ts
+++ b/frontend/src/util/backend.ts
@@ -2,10 +2,20 @@ import axios, { AxiosRequestHeaders } from "axios";
 
 const BE_URL: string = process.env.VUE_APP_BACKEND_URL;
 
-export async function beGET(endpoint: string, headers?: AxiosRequestHeaders) {
-  return await (await axios.get(`${BE_URL}/${endpoint}`, { headers })).data as Record<string, unknown>;
+export async function beGET(endpoint: string, headers?: AxiosRequestHeaders): Promise<{ statusCode: number, data: Record<string, unknown> }> {
+  const response = await axios.get(`${BE_URL}/${endpoint}`, { headers });
+
+  return {
+    statusCode: response.status,
+    data: await response.data as Record<string, unknown>,
+  };
 }
 
-export async function bePOST(endpoint: string, data: Record<string, unknown>, headers?: AxiosRequestHeaders) {
-  return await (await axios.post(`${BE_URL}/${endpoint}`, data, { headers })).data as Record<string, unknown>;
+export async function bePOST(endpoint: string, data: Record<string, unknown>, headers?: AxiosRequestHeaders): Promise<{ statusCode: number, data: Record<string, unknown> }> {
+  const response = await axios.post(`${BE_URL}/${endpoint}`, data, { headers });
+
+  return {
+    statusCode: response.status,
+    data: await response.data as Record<string, unknown>,
+  };
 }


### PR DESCRIPTION
### 전역
- 네비바 계정 영역 클릭 시 표시되는 메뉴 추가 (프로필 보기, 로그아웃)
- 네비바 뒤로 가기 버튼 표시 효과 수정 ([위키 내용 참고](https://github.com/SWM-TEAM-GOYUKKURI/ToAnyone/wiki/%5BFE%5D-Vue-transition-%EA%B4%80%EB%A0%A8-%EC%82%BD%EC%A7%88))
- 네비바 계정 영역이 특정 페이지에선 표시되지 않게 설정 가능
  * 프로필 페이지, 프로필 수정 페이지에 적용

### 프로필 페이지
- 페이지 필요 콘텐츠 영역 생성 (스타일링은 일부 진행)

### 로그아웃
- 로그아웃 페이지 및 기능 구현
  * 세션 쿠키 제거, 관련 Vuex store 객체 제거

Closes #37
Closes #38
Depends #30 