### PR TITLE
fix: respsone and authentication Error

### DIFF
--- a/backend/src/main/java/anyone/to/soma/letter/application/LetterService.java
+++ b/backend/src/main/java/anyone/to/soma/letter/application/LetterService.java
@@ -28,10 +28,7 @@ public class LetterService {
     @Transactional
     public SingleLetterResponse retrieveInboxSingleLetter(Long letterId, Long userId) {
         Letter letter = letterRepository.findById(letterId).orElseThrow(NoSuchRecordException::new);
-
-        if (!letter.getReceiver().getId().equals(userId)) {
-            throw new ApplicationException("잘못된 권한입니다.");
-        }
+        letter.checkValidReader(userId);
 
         return SingleLetterResponse.of(letter, letter.getReceiver().getNickname(), letter.getReplyLetters());
     }

--- a/backend/src/main/java/anyone/to/soma/letter/application/LetterService.java
+++ b/backend/src/main/java/anyone/to/soma/letter/application/LetterService.java
@@ -72,13 +72,13 @@ public class LetterService {
             throw new ApplicationException("잘못된 권한입니다.");
         }
 
-        ReplyLetter replyLetter = new ReplyLetter(request.getContent(), LocalDate.now(), letter, sender.getNickname(), letter.getReceiver().getNickname(), request.getDecorations());
+        ReplyLetter replyLetter = new ReplyLetter(request.getContent(), LocalDate.now(), letter, sender.getNickname(), letter.findReplyLetterSender(sender).getNickname(), request.getDecorations());
         letter.reply(replyLetter);
     }
 
     public List<InboxLetterResponse> retrieveSentLetters(User sender) {
         List<Letter> sentLetters = letterRepository.findLettersBySenderId(sender.getId());
-        return InboxLetterResponse.listOf(sentLetters, sender.getNickname());
+        return InboxLetterResponse.sentLetterListOf(sentLetters, sender.getNickname());
     }
 
     @Transactional

--- a/backend/src/main/java/anyone/to/soma/letter/domain/Letter.java
+++ b/backend/src/main/java/anyone/to/soma/letter/domain/Letter.java
@@ -83,4 +83,17 @@ public class Letter implements Serializable {
         }
 
     }
+
+    public User findReplyLetterSender(User user) {
+        if (this.sender.getId().equals(user.getId())) {
+            return this.receiver;
+        }
+
+        if (this.receiver.getId().equals(user.getId())) {
+            return this.sender;
+        }
+
+        throw new ApplicationException("편지를 전달할 사람이 없습니다.");
+
+    }
 }

--- a/backend/src/main/java/anyone/to/soma/letter/domain/dto/InboxLetterResponse.java
+++ b/backend/src/main/java/anyone/to/soma/letter/domain/dto/InboxLetterResponse.java
@@ -28,15 +28,15 @@ public class InboxLetterResponse {
     private boolean isRead;
     private List<DecorationType> decorations;
 
-    public static InboxLetterResponse of(Letter letter, String receiverName) {
+    public static InboxLetterResponse of(Letter letter, String senderName) {
         List<DecorationType> letterDecorations = letter.getLetterDecorations().stream().map(LetterDecoration::getDecorationType).collect(Collectors.toList());
         String content = letter.getContent();
-        return new InboxLetterResponse(letter.getId(), content.substring(0, Math.min(content.length(), MAX_CONTENT_LENGTH)), letter.getSendDate(), receiverName, letter.getSender().getNickname(), readPolicy(letter), letterDecorations);
+        return new InboxLetterResponse(letter.getId(), content.substring(0, Math.min(content.length(), MAX_CONTENT_LENGTH)), letter.getSendDate(), letter.getReceiver().getNickname(), senderName, readPolicy(letter), letterDecorations);
     }
 
-    public static List<InboxLetterResponse> listOf(List<Letter> letters, String receiverName) {
+    public static List<InboxLetterResponse> listOf(List<Letter> letters, String senderName) {
         return letters.stream()
-                .map(s -> InboxLetterResponse.of(s, receiverName))
+                .map(s -> InboxLetterResponse.of(s, senderName))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/anyone/to/soma/letter/domain/dto/InboxLetterResponse.java
+++ b/backend/src/main/java/anyone/to/soma/letter/domain/dto/InboxLetterResponse.java
@@ -28,21 +28,34 @@ public class InboxLetterResponse {
     private boolean isRead;
     private List<DecorationType> decorations;
 
-    public static InboxLetterResponse of(Letter letter, String senderName) {
-        List<DecorationType> letterDecorations = letter.getLetterDecorations().stream().map(LetterDecoration::getDecorationType).collect(Collectors.toList());
-        String content = letter.getContent();
-        return new InboxLetterResponse(letter.getId(), content.substring(0, Math.min(content.length(), MAX_CONTENT_LENGTH)), letter.getSendDate(), letter.getReceiver().getNickname(), senderName, readPolicy(letter), letterDecorations);
-    }
-
-    public static List<InboxLetterResponse> listOf(List<Letter> letters, String senderName) {
+    public static List<InboxLetterResponse> sentLetterListOf(List<Letter> letters, String senderName) {
         return letters.stream()
-                .map(s -> InboxLetterResponse.of(s, senderName))
+                .map(s -> InboxLetterResponse.sentLetterOf(s, senderName))
                 .collect(Collectors.toList());
     }
 
-    private static boolean readPolicy(Letter letter){
+    private static InboxLetterResponse sentLetterOf(Letter letter, String senderName) {
+        List<DecorationType> letterDecorations = letter.getLetterDecorations().stream().map(LetterDecoration::getDecorationType).collect(Collectors.toList());
+        String content = letter.getContent();
+        return new InboxLetterResponse(letter.getId(), content.substring(0, Math.min(content.length(), MAX_CONTENT_LENGTH)), letter.getSendDate(), letter.getReceiver().getNickname(), senderName, true, letterDecorations);
+    }
+
+    public static List<InboxLetterResponse> listOf(List<Letter> letters, String receiverName) {
+        return letters.stream()
+                .map(s -> InboxLetterResponse.of(s, receiverName))
+                .collect(Collectors.toList());
+    }
+
+    private static InboxLetterResponse of(Letter letter, String receiverName) {
+        List<DecorationType> letterDecorations = letter.getLetterDecorations().stream().map(LetterDecoration::getDecorationType).collect(Collectors.toList());
+        String content = letter.getContent();
+        return new InboxLetterResponse(letter.getId(), content.substring(0, Math.min(content.length(), MAX_CONTENT_LENGTH)), letter.getSendDate(), receiverName, letter.getSender().getNickname(), readPolicy(letter), letterDecorations);
+    }
+
+
+    private static boolean readPolicy(Letter letter) {
         List<ReplyLetter> replyLetters = letter.getReplyLetters();
-        if (replyLetters.isEmpty()){
+        if (replyLetters.isEmpty()) {
             return letter.isRead();
         }
 


### PR DESCRIPTION
- 편지를 전송한 계정에서 /letter/sent의 응답에 나타나는 편지의 편지 데이터를 요청(/letter/inbox/:id)할 떄, 수신자는 읽지 못하게 권한을 설정한 부분을 변경했습니다.
- dto에서 sender와 receiver가 같이 나오는 오류를 수정했습니다.