### PR TITLE
fix: 직접 쿼리를 찌르도록 변경

### DIFF
--- a/backend/src/main/java/anyone/to/soma/letter/domain/Letter.java
+++ b/backend/src/main/java/anyone/to/soma/letter/domain/Letter.java
@@ -102,6 +102,6 @@ public class Letter extends AbstractAggregateRoot<Letter> {
 
     @PostPersist
     public void created() {
-        this.registerEvent(new LetterCreatedEvent(this.id, this.sender.getId(), this.sender.getUserAchievement().getSendLetterCountValue(), this.receiver.getReceiveCount()));
+        this.registerEvent(new LetterCreatedEvent(this.id, this.sender.getId(), this.receiver.getId()));
     }
 }

--- a/backend/src/main/java/anyone/to/soma/letter/domain/event/LetterCreatedEvent.java
+++ b/backend/src/main/java/anyone/to/soma/letter/domain/event/LetterCreatedEvent.java
@@ -2,34 +2,27 @@ package anyone.to.soma.letter.domain.event;
 
 public class LetterCreatedEvent {
 
-    private Long id;
+    private Long letterId;
 
-    private Long userId;
+    private Long senderId;
 
-    private int sentCount;
+    private Long receiverId;
 
-    private int receiveCount;
-
-    public LetterCreatedEvent(Long id, Long userId, int sentCount, int receiveCount) {
-        this.id = id;
-        this.userId = userId;
-        this.sentCount = sentCount;
-        this.receiveCount = receiveCount;
+    public LetterCreatedEvent(Long letterId, Long senderId, Long receiverId) {
+        this.letterId = letterId;
+        this.senderId = senderId;
+        this.receiverId = receiverId;
     }
 
-    public Long getId() {
-        return id;
+    public Long getLetterId() {
+        return letterId;
     }
 
-    public Long getUserId() {
-        return userId;
+    public Long getSenderId() {
+        return senderId;
     }
 
-    public int getSentCount() {
-        return sentCount;
-    }
-
-    public int getReceiveCount() {
-        return receiveCount;
+    public Long getReceiverId() {
+        return receiverId;
     }
 }


### PR DESCRIPTION
JPQL을 통해 변경한(UPDATE 쿼리) 내용이 이벤트 리스너에서 이벤트 객체 값에 적용이 안되어 이를 이벤트 객체가 아닌, 조회를 통해 진행하도록 변경했습니다.